### PR TITLE
[nrf noup] cmake: Fix build warning

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -4,27 +4,31 @@
 # SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
 #
 
+if (NOT CONFIG_WFA_QT_CONTROL_APP)
+	return()
+endif()
+
 zephyr_library()
 
 set(SOURCES_BASE ${CMAKE_CURRENT_SOURCE_DIR}/../)
 # Enable of same options as upstream points to issues with Zephyr
 # headers, so, for now, we disable them.
-zephyr_library_compile_options_ifdef(CONFIG_WFA_QT_CONTROL_APP
+zephyr_library_compile_options(
 	-Werror
 	# False positive, not going away even with null check
 	-Wno-format-overflow
 )
 
-zephyr_library_compile_definitions_ifdef(CONFIG_WFA_QT_CONTROL_APP
+zephyr_library_compile_definitions(
 	CONFIG_ZEPHYR
 )
 
-zephyr_include_directories_ifdef(CONFIG_WFA_QT_CONTROL_APP
+zephyr_include_directories(
 	${SOURCES_BASE}
 	${SOURCES_BASE}/zephyr/include
 )
 
-zephyr_library_sources_ifdef(CONFIG_WFA_QT_CONTROL_APP
+zephyr_library_sources(
 	# Zephyr's port of the Indigo API
 	${SOURCES_BASE}/zephyr/src/main.c
 	${SOURCES_BASE}/zephyr/src/indigo_api_callback_dut.c


### PR DESCRIPTION
As QT Kconfig is unconditionally included for all builds where QT is mostly not enabled this causes a Cmake warning "No SOURCES given", to fix this warning add a check and return early if QT is not enabled.