### PR TITLE
[nrf noup] ci: Disable Kconfig for modules

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -72,6 +72,7 @@ jobs:
         -e KconfigBasic \
         -e checkpatch  \
         -e Kconfig \
+        -e KconfigBasicNoModules \
         -e DevicetreeBindings \
         -c origin/${BASE_REF}..
 


### PR DESCRIPTION
fixup! [nrf noup] ci: Add compliance check

This is a false negative and is also disabled in the sdk-zephyr.