### PR TITLE
[nrf noup]: zephyr: qt: [nrf noup]: zephyr: qt: Address association request capture failure

### DIFF
--- a/zephyr/src/indigo_api_callback_dut.c
+++ b/zephyr/src/indigo_api_callback_dut.c
@@ -1870,16 +1870,6 @@ static int configure_sta_handler(struct packet_wrapper *req, struct packet_wrapp
 
     generate_sta_config(w, req);
 
-    memset(buffer, 0, sizeof(buffer));
-    sprintf(buffer, "ENABLE_NETWORK 0");
-    memset(response, 0, sizeof(response));
-    resp_len = sizeof(response) - 1;
-    wpa_ctrl_request(w, buffer, strlen(buffer), response, &resp_len, NULL);
-    if (strncmp(response, WPA_CTRL_OK, strlen(WPA_CTRL_OK)) != 0) {
-        indigo_logger(LOG_LEVEL_ERROR, "Failed to execute the command. Response: %s", response);
-        goto done;
-    }
-
 done:
     fill_wrapper_message_hdr(resp, API_CMD_RESPONSE, req->hdr.seq);
     fill_wrapper_tlv_byte(resp, TLV_STATUS, status);
@@ -1909,6 +1899,16 @@ static int associate_sta_handler(struct packet_wrapper *req, struct packet_wrapp
         indigo_logger(LOG_LEVEL_ERROR, "Failed to connect to wpa_supplicant");
         status = TLV_VALUE_STATUS_NOT_OK;
         message = TLV_VALUE_WPA_S_START_UP_NOT_OK;
+        goto done;
+    }
+
+    memset(buffer, 0, sizeof(buffer));
+    sprintf(buffer, "ENABLE_NETWORK 0");
+    memset(response, 0, sizeof(response));
+    resp_len = sizeof(response) - 1;
+    wpa_ctrl_request(w, buffer, strlen(buffer), response, &resp_len, NULL);
+    if (strncmp(response, WPA_CTRL_OK, strlen(WPA_CTRL_OK)) != 0) {
+        indigo_logger(LOG_LEVEL_ERROR, "Failed to execute the command. Response: %s", response);
         goto done;
     }
 


### PR DESCRIPTION
…ssociate API

The `enable_network` command is part of the configure API, and it is resulting in advance connection and causing QT tool failures in capturing association frames after sending association command.

To address the issue, move the `enable_network` command from the configure API to the association API to ensure that the connection is established only after receiving the association request command.

Fixes SHEL-1861 and SHEL-1862