### PR TITLE
[nrf noup] zephyr: Fix CI

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Install python dependencies
       working-directory: wfa_qt_app
       run: |
+        pip3 install -U west
         pip3 install -U pip
         pip3 install -U setuptools
         pip3 install -U wheel
@@ -73,6 +74,7 @@ jobs:
         -e checkpatch  \
         -e Kconfig \
         -e KconfigBasicNoModules \
+        -e ModulesMaintainers \
         -e DevicetreeBindings \
         -c origin/${BASE_REF}..
 


### PR DESCRIPTION
xiup![nrf noup] ci: Add compliance check

Recent Zephyr has made west python package mandatory, so, install the west package. But disable the module maintainers test as it needs west update and also we don't use the maintainers for this repo.