### PR TITLE
ci: Upgrade artifact actions

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -79,12 +79,13 @@ jobs:
         -c origin/${BASE_REF}..
 
     - name: upload-results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       continue-on-error: true
       if: contains(github.event.pull_request.user.login, 'dependabot[bot]') != true
       with:
         name: compliance.xml
         path: wfa_qt_app/compliance.xml
+        overwrite: true
 
     - name: check-warns
       working-directory: wfa_qt_app


### PR DESCRIPTION
v3 of actions/upload-artifact and
actions/download-artifact becomes obsolete.

From: https://github.com/orgs/community/discussions/142581